### PR TITLE
Remove Bad Runs from Fill 8102 and Misc Updates to picoNtupler_TandP.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,12 @@ The following command does the same thing, but for tau eta (necessary to include
 ```
 python3 plotter_from_ntuplizer.py --input picoNtuple.root --channel ditau --run "Fill 8102" --plot testplot --var tau_eta --iseta
 ```
+
+# Summary of scripts in `producer`
+picoNtuplizer.py makes ntuples
+plotter_from_Ntuplizer.py and multiplotter_from_Ntuplizer.py both make plots using an ntuple as input (as seen above)
+picoNtupler_TandP.py makes plots using nanoAOD files (i.e. not remade ntuples)
+importantly the `obtain_histograms` function in picoNtupler_TandP.py is slightly different from the same function found in plotter_from_Ntuplizer.py
+importantly the `plot` function in picoNtupler_TandP.py is used by all other files
+multiplotter.py is a script that makes multiple graphs (so far only ditaujet paths are supported here)
+

--- a/README.md
+++ b/README.md
@@ -12,6 +12,19 @@ The following command does the same thing, but for tau eta (necessary to include
 python3 plotter_from_ntuplizer.py --input picoNtuple.root --channel ditau --run "Fill 8102" --plot testplot --var tau_eta --iseta
 ```
 
+`plot_comparison.py` is made to compare either the same path on different datasets or different paths on the same dataset.
+For now, the legend lable of the script is hardcoded, so the first sample is always written as using DeepTau v2p1
+and the second as using DeepTau v2p5.
+To use plot_comparison.py in this way, first produce two different ntuples using picoNtuplizer.py with 2p1 and 2p5, then run the following command.
+```
+python3 plot_comparison.py \
+--input_A Fill8102_DeepTauV2p1_New.root \
+--input_B Fill8136_DeepTauV2p5_New.root \
+--channel_A VBFditau_Run3_tauleg \
+--channel_B VBFditau_Run3_tauleg \
+--run "Compare DeepTau" --plot testplot --var tau_pt
+```
+
 # Summary of scripts in `producer`
 picoNtuplizer.py makes ntuples
 plotter_from_Ntuplizer.py and multiplotter_from_Ntuplizer.py both make plots using an ntuple as input (as seen above)

--- a/README.md
+++ b/README.md
@@ -14,9 +14,14 @@ python3 plotter_from_ntuplizer.py --input picoNtuple.root --channel ditau --run 
 
 # Summary of scripts in `producer`
 picoNtuplizer.py makes ntuples
+
 plotter_from_Ntuplizer.py and multiplotter_from_Ntuplizer.py both make plots using an ntuple as input (as seen above)
+
 picoNtupler_TandP.py makes plots using nanoAOD files (i.e. not remade ntuples)
+
 importantly the `obtain_histograms` function in picoNtupler_TandP.py is slightly different from the same function found in plotter_from_Ntuplizer.py
+
 importantly the `plot` function in picoNtupler_TandP.py is used by all other files
+
 multiplotter.py is a script that makes multiple graphs (so far only ditaujet paths are supported here)
 

--- a/producer/picoNtupler_TandP.py
+++ b/producer/picoNtupler_TandP.py
@@ -187,28 +187,45 @@ def plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVari
     ROOT.gStyle.SetOptStat(0); ROOT.gStyle.SetTextFont(42)
     c = ROOT.TCanvas("c", "", 800, 700)
 
-    # Nuclear option, use multiplotter
+    # use multiplotter for multiple graphs
+    mg = ROOT.TMultiGraph("mg", "")
 
     # this divides num by den.
     # the "Clopper-Pearson" interval is used
     # https://root.cern.ch/doc/master/classTGraphAsymmErrors.html#a37a202762b286cf4c7f5d34046be8c0b
     gr_A = ROOT.TGraphAsymmErrors(h_num_os_A.GetPtr(),h_den_os_A.GetPtr(),"cp")
     gr_A.SetTitle("")
-    gr_A.SetLineColor(2)
-    gr_A.SetMarkerStyle(21)
+    gr_A.SetLineColor(2) # this is red
+    gr_A.SetMarkerStyle(21) # this is a filled box
     gr_A.SetMarkerSize(1.5)
+
+
+    gr_B = ROOT.TGraphAsymmErrors(h_num_os_B.GetPtr(),h_den_os_B.GetPtr(),"cp")
+    gr_B.SetTitle("")
+    gr_B.SetLineColor(9) # this is blue
+    gr_B.SetMarkerStyle(20) # this is a filled circle
+    gr_B.SetMarkerColor(12) # this is a light grey
+    gr_B.SetMarkerSize(1.4)
+
+    mg.Add(gr_A)
+    mg.Add(gr_B)
     # "P" forces the use of the chosen marker
     # "A" draws without the axis 
     # somehow the plot is not drawn without this argument
     # https://root.cern/doc/master/classTHistPainter.html#HP01a
-    gr_A.Draw("AP")
+    mg.Draw("AP")
 
-    gr_B = ROOT.TGraphAsymmErrors(h_num_os_B.GetPtr(),h_den_os_B.GetPtr(),"cp")
-    gr_B.SetTitle("")
-    gr_B.SetLineColor(9) # somehow this is being overwritten
-    gr_B.SetMarkerStyle(20)
-    gr_B.SetMarkerSize(1.5)
-    gr_B.Draw("P")
+    label = ROOT.TLatex(); label.SetNDC(True)
+    if(plottingVariable == "tau_pt" or plottingVariable=="tau_l1pt"):
+        label.DrawLatex(0.8, 0.03, "#tau_{pT}")
+    elif(plottingVariable == "jet_pt"):
+        label.DrawLatex(0.8, 0.03, "jet_{pT}")
+    elif(plottingVariable == "jet_eta"):
+        label.DrawLatex(0.8, 0.03, "#eta_{jet}")
+    else:
+        label.DrawLatex(0.8, 0.03, "#eta_{#tau}")
+    label.SetTextSize(0.040); label.DrawLatex(0.100, 0.920, "#bf{CMS Run3 Data}")
+    label.SetTextSize(0.030); label.DrawLatex(0.630, 0.920, "#sqrt{s} = 13.6 TeV, %s" % add_to_label)
 
     combined_name = channel_A + "_" + channel_B
     c.SaveAs("%s_%s_%s.png" % (plotName, combined_name, plottingVariable))

--- a/producer/picoNtupler_TandP.py
+++ b/producer/picoNtupler_TandP.py
@@ -201,7 +201,6 @@ def plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVari
     # "A" draws without the axis 
     # somehow the plot is not drawn without this argument
     # https://root.cern/doc/master/classTHistPainter.html#HP01a
-    #gr_A.Draw("AP")
     gr_A.Draw("AP")
 
     gr_B = ROOT.TGraphAsymmErrors(h_num_os_B.GetPtr(),h_den_os_B.GetPtr(),"cp")
@@ -209,7 +208,7 @@ def plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVari
     gr_B.SetLineColor(9) # somehow this is being overwritten
     gr_B.SetMarkerStyle(20)
     gr_B.SetMarkerSize(1.5)
-    gr_B.Draw("PLC")
+    gr_B.Draw("P")
 
     combined_name = channel_A + "_" + channel_B
     c.SaveAs("%s_%s_%s.png" % (plotName, combined_name, plottingVariable))

--- a/producer/picoNtupler_TandP.py
+++ b/producer/picoNtupler_TandP.py
@@ -187,24 +187,30 @@ if __name__ == '__main__':
     channel = args.channel
     iseta = args.iseta
     plottingVariable = args.var
+    run = args.run
 
     #inputFiles = (f'/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/SingleMuonV1/Files2/nano_aod_{i}.root' for i in range(0,79))
 
     folders = [
-        # "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356943/",
-        # "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356944/",
-        # "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356945/",
-        # "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356946/",
-        # "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356947/",
-        # "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356948/",
-        # "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356949/",
-        # "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356951/",
-        # "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356954/",
-        # "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356955/",
-        # "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356956/",
+        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356944/",
+        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356946/",
+        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356947/",
+        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356948/",
+        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356949/",
+        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356951/",
+        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356954/",
+        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356955/",
+        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356956/",
         "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/savarghe/nanoaod/eraD/Fill8136/Muon/"
     ]
 
+    if "8102" in run:
+      print("Using run 8102 files")
+      folders = [entry for entry in folders if "8102" in entry]
+    else:
+      print("Using run 8136 files")
+      folders = [entry for entry in folders if "8136" in entry]
+
     df = create_rdataframe(folders)
     h_num_os, h_den_os = obtain_histograms(df, channel, iseta, plottingVariable)
-    plot(h_num_os, h_den_os, plottingVariable, channel, args.run, args.plot)
+    plot(h_num_os, h_den_os, plottingVariable, channel, run, args.plot)

--- a/producer/picoNtupler_TandP.py
+++ b/producer/picoNtupler_TandP.py
@@ -59,7 +59,7 @@ def obtain_histograms(df, channel, iseta, plottingVariable):
 
     ## select tau (probe) candidate
     df_probe = df_tag.Filter("Muon_Index >= 0 && muon_iso < 0.1 && HLT_IsoMu24_eta2p1 == 1").Define("Tau_Index",\
-                 "TauIndex(nTau, Tau_pt, Tau_eta, Tau_phi, Tau_mass, Tau_dz, muon_p4)")
+                 "TauIndex(nTau, Tau_pt, Tau_eta, Tau_phi, Tau_mass, Tau_dz, muon_p4, Tau_rawDeepTau2018v2p5VSjet)")
 
     df_probe_id = df_probe.Filter("Tau_Index >= 0 && \
                                    Tau_decayMode[Tau_Index] != 5 && Tau_decayMode[Tau_Index] != 6 && Tau_idDeepTau2018v2p5VSjet[Tau_Index]==5").Define("tau_p4","Obj_p4(Tau_Index, Tau_pt, Tau_eta, Tau_phi, Tau_mass)")

--- a/producer/picoNtupler_TandP.py
+++ b/producer/picoNtupler_TandP.py
@@ -183,59 +183,6 @@ def plot(h_num_os, h_den_os, plottingVariable, channel, add_to_label, plotName):
     c.SaveAs("%s_%s_%s.pdf" % (plotName, channel, plottingVariable))
     c.SaveAs("%s_%s_%s.png" % (plotName, channel, plottingVariable))
 
-def plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVariable, channel_A, channel_B, add_to_label, plotName):
-    print("Plotting {} of {} and {}".format(plottingVariable, channel_A, channel_B))
-    ROOT.gStyle.SetOptStat(0); ROOT.gStyle.SetTextFont(42)
-    c = ROOT.TCanvas("c", "", 800, 700)
-
-    # use multiplotter for multiple graphs
-    mg = ROOT.TMultiGraph("mg", "")
-
-    # this divides num by den.
-    # the "Clopper-Pearson" interval is not supported for
-    # TGraphAsymmErrors::Divide, so i changed "cp" to "n"
-    # the graphs are not changed
-    # https://root.cern.ch/doc/master/classTGraphAsymmErrors.html#a37a202762b286cf4c7f5d34046be8c0b
-    # use "nv" to get per-bin efficiency printed to terminal
-    gr_A = ROOT.TGraphAsymmErrors(h_num_os_A.GetPtr(),h_den_os_A.GetPtr(), "n")
-    gr_A.SetTitle("")
-    gr_A.SetLineColor(2) # this is red
-    gr_A.SetMarkerStyle(21) # this is a filled box
-    gr_A.SetMarkerSize(1.5)
-
-
-    gr_B = ROOT.TGraphAsymmErrors(h_num_os_B.GetPtr(),h_den_os_B.GetPtr(), "n")
-    gr_B.SetTitle("")
-    gr_B.SetLineColor(9) # this is blue
-    gr_B.SetMarkerStyle(20) # this is a filled circle
-    gr_B.SetMarkerColor(12) # this is a light grey
-    gr_B.SetMarkerSize(1.4)
-
-    mg.Add(gr_A)
-    mg.Add(gr_B)
-    # "P" forces the use of the chosen marker
-    # "A" draws without the axis 
-    # somehow the plot is not drawn without this argument
-    # https://root.cern/doc/master/classTHistPainter.html#HP01a
-    mg.Draw("AP")
-
-    label = ROOT.TLatex(); label.SetNDC(True)
-    if(plottingVariable == "tau_pt" or plottingVariable=="tau_l1pt"):
-        label.DrawLatex(0.8, 0.03, "#tau_{pT}")
-    elif(plottingVariable == "jet_pt"):
-        label.DrawLatex(0.8, 0.03, "jet_{pT}")
-    elif(plottingVariable == "jet_eta"):
-        label.DrawLatex(0.8, 0.03, "#eta_{jet}")
-    else:
-        label.DrawLatex(0.8, 0.03, "#eta_{#tau}")
-    label.SetTextSize(0.040); label.DrawLatex(0.100, 0.920, "#bf{CMS Run3 Data}")
-    label.SetTextSize(0.030); label.DrawLatex(0.630, 0.920, "#sqrt{s} = 13.6 TeV, %s" % add_to_label)
-
-    combined_name = channel_A + "_" + channel_B
-    c.SaveAs("%s_%s_%s.pdf" % (plotName, combined_name, plottingVariable))
-    c.SaveAs("%s_%s_%s.png" % (plotName, combined_name, plottingVariable))
-
-
 
 if __name__ == '__main__':
     args = parser.parse_args()

--- a/producer/picoNtupler_TandP.py
+++ b/producer/picoNtupler_TandP.py
@@ -207,4 +207,4 @@ if __name__ == '__main__':
 
     df = create_rdataframe(folders)
     h_num_os, h_den_os = obtain_histograms(df, channel, iseta, plottingVariable)
-    plot(h_num_os, h_den_os, plottingVariable, channnel, args.run, args.plot)
+    plot(h_num_os, h_den_os, plottingVariable, channel, args.run, args.plot)

--- a/producer/picoNtupler_TandP.py
+++ b/producer/picoNtupler_TandP.py
@@ -191,16 +191,19 @@ def plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVari
     mg = ROOT.TMultiGraph("mg", "")
 
     # this divides num by den.
-    # the "Clopper-Pearson" interval is used
+    # the "Clopper-Pearson" interval is not supported for
+    # TGraphAsymmErrors::Divide, so i changed "cp" to "n"
+    # the graphs are not changed
     # https://root.cern.ch/doc/master/classTGraphAsymmErrors.html#a37a202762b286cf4c7f5d34046be8c0b
-    gr_A = ROOT.TGraphAsymmErrors(h_num_os_A.GetPtr(),h_den_os_A.GetPtr(),"cp")
+    # use "nv" to get per-bin efficiency printed to terminal
+    gr_A = ROOT.TGraphAsymmErrors(h_num_os_A.GetPtr(),h_den_os_A.GetPtr(), "n")
     gr_A.SetTitle("")
     gr_A.SetLineColor(2) # this is red
     gr_A.SetMarkerStyle(21) # this is a filled box
     gr_A.SetMarkerSize(1.5)
 
 
-    gr_B = ROOT.TGraphAsymmErrors(h_num_os_B.GetPtr(),h_den_os_B.GetPtr(),"cp")
+    gr_B = ROOT.TGraphAsymmErrors(h_num_os_B.GetPtr(),h_den_os_B.GetPtr(), "n")
     gr_B.SetTitle("")
     gr_B.SetLineColor(9) # this is blue
     gr_B.SetMarkerStyle(20) # this is a filled circle
@@ -228,6 +231,7 @@ def plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVari
     label.SetTextSize(0.030); label.DrawLatex(0.630, 0.920, "#sqrt{s} = 13.6 TeV, %s" % add_to_label)
 
     combined_name = channel_A + "_" + channel_B
+    c.SaveAs("%s_%s_%s.pdf" % (plotName, combined_name, plottingVariable))
     c.SaveAs("%s_%s_%s.png" % (plotName, combined_name, plottingVariable))
 
 

--- a/producer/picoNtupler_TandP.py
+++ b/producer/picoNtupler_TandP.py
@@ -180,6 +180,7 @@ def plot(h_num_os, h_den_os, plottingVariable, channel, add_to_label, plotName):
     label.SetTextSize(0.030); label.DrawLatex(0.630, 0.920, "#sqrt{s} = 13.6 TeV, %s" % add_to_label)
 
     c.SaveAs("%s_%s_%s.pdf" % (plotName, channel, plottingVariable))
+    c.SaveAs("%s_%s_%s.png" % (plotName, channel, plottingVariable))
 
 
 if __name__ == '__main__':

--- a/producer/picoNtupler_TandP.py
+++ b/producer/picoNtupler_TandP.py
@@ -58,6 +58,7 @@ def obtain_histograms(df, channel, iseta, plottingVariable):
               "Obj_p4(Muon_Index, Muon_pt, Muon_eta, Muon_phi, Muon_mass)").Define("muon_iso","getFloatValue(Muon_pfRelIso04_all, Muon_Index)")
 
     ## select tau (probe) candidate
+    print("FIXME: If Fill 8102, change Tau_rawDeepTau2018v2p5VSjet to Tau_rawDeepTau2017v2p1VSjet")
     df_probe = df_tag.Filter("Muon_Index >= 0 && muon_iso < 0.1 && HLT_IsoMu24_eta2p1 == 1").Define("Tau_Index",\
                  "TauIndex(nTau, Tau_pt, Tau_eta, Tau_phi, Tau_mass, Tau_dz, muon_p4, Tau_rawDeepTau2018v2p5VSjet)")
 

--- a/producer/picoNtupler_TandP.py
+++ b/producer/picoNtupler_TandP.py
@@ -182,6 +182,39 @@ def plot(h_num_os, h_den_os, plottingVariable, channel, add_to_label, plotName):
     c.SaveAs("%s_%s_%s.pdf" % (plotName, channel, plottingVariable))
     c.SaveAs("%s_%s_%s.png" % (plotName, channel, plottingVariable))
 
+def plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVariable, channel_A, channel_B, add_to_label, plotName):
+    print("Plotting {} of {} and {}".format(plottingVariable, channel_A, channel_B))
+    ROOT.gStyle.SetOptStat(0); ROOT.gStyle.SetTextFont(42)
+    c = ROOT.TCanvas("c", "", 800, 700)
+
+    # Nuclear option, use multiplotter
+
+    # this divides num by den.
+    # the "Clopper-Pearson" interval is used
+    # https://root.cern.ch/doc/master/classTGraphAsymmErrors.html#a37a202762b286cf4c7f5d34046be8c0b
+    gr_A = ROOT.TGraphAsymmErrors(h_num_os_A.GetPtr(),h_den_os_A.GetPtr(),"cp")
+    gr_A.SetTitle("")
+    gr_A.SetLineColor(2)
+    gr_A.SetMarkerStyle(21)
+    gr_A.SetMarkerSize(1.5)
+    # "P" forces the use of the chosen marker
+    # "A" draws without the axis 
+    # somehow the plot is not drawn without this argument
+    # https://root.cern/doc/master/classTHistPainter.html#HP01a
+    #gr_A.Draw("AP")
+    gr_A.Draw("AP")
+
+    gr_B = ROOT.TGraphAsymmErrors(h_num_os_B.GetPtr(),h_den_os_B.GetPtr(),"cp")
+    gr_B.SetTitle("")
+    gr_B.SetLineColor(9) # somehow this is being overwritten
+    gr_B.SetMarkerStyle(20)
+    gr_B.SetMarkerSize(1.5)
+    gr_B.Draw("PLC")
+
+    combined_name = channel_A + "_" + channel_B
+    c.SaveAs("%s_%s_%s.png" % (plotName, combined_name, plottingVariable))
+
+
 
 if __name__ == '__main__':
     args = parser.parse_args()

--- a/producer/picoNtupler_TandP.py
+++ b/producer/picoNtupler_TandP.py
@@ -161,7 +161,7 @@ def plot(h_num_os, h_den_os, plottingVariable, channel, add_to_label, plotName):
     ROOT.gStyle.SetOptStat(0); ROOT.gStyle.SetTextFont(42)
     c = ROOT.TCanvas("c", "", 800, 700)
 
-    gr = ROOT.TGraphAsymmErrors(h_num_os.GetPtr(),h_den_os.GetPtr(),"cp")
+    gr = ROOT.TGraphAsymmErrors(h_num_os.GetPtr(),h_den_os.GetPtr(),"n")
     gr.SetTitle("")
     gr.SetMarkerStyle(21)
     gr.SetMarkerSize(1.5)

--- a/producer/picoNtuplizer.py
+++ b/producer/picoNtuplizer.py
@@ -20,6 +20,7 @@ from RooPlottingTool import *
 # select the version
 TauID_ver = sys.argv[1]
 outFile   = sys.argv[2]
+useFiles = sys.argv[3] #8102, 8136, or filename.txt
 
 def create_rdataframe(folders, inputFiles=None):
     if not inputFiles:
@@ -55,7 +56,8 @@ def obtain_picontuple(df):
         df = df.Define("Tau_goodid",
             "getIntValue(Tau_decayMode, Tau_Index) != 5 && "
             "getIntValue(Tau_decayMode, Tau_Index) != 6 && "
-            "getIntValue(Tau_idDeepTau2017v2p1VSjet, Tau_Index) >= 16"
+            #"getIntValue(Tau_idDeepTau2017v2p1VSjet, Tau_Index) >= 16"
+            "getIntValue(Tau_idDeepTau2017v2p1VSjet, Tau_Index) >= 5"
         ).Define("tau_p4","Obj_p4(Tau_Index, Tau_pt, Tau_eta, Tau_phi, Tau_mass)")
         branches += ["Tau_goodid", "Tau_decayMode", "Tau_idDeepTau2017v2p1VSjet"] 
     elif TauID_ver == '2p5':
@@ -123,20 +125,48 @@ if __name__ == '__main__':
 
     #inputFiles = (f'/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/SingleMuonV1/Files2/nano_aod_{i}.root' for i in range(0,79))
 
+    useFiles = str(useFiles)
+
     folders = [
-        #"/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356944/",
-        #"/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356946/",
-        #"/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356947/",
-        #"/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356948/",
-        #"/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356949/",
-        #"/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356951/",
-        #"/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356954/",
-        #"/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356955/",
-        #"/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356956/"
-         "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/savarghe/nanoaod/eraD/Fill8136/Muon/"
+        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356944/",
+        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356946/",
+        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356947/",
+        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356948/",
+        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356949/",
+        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356951/",
+        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356954/",
+        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356955/",
+        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356956/",
+        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/savarghe/nanoaod/eraD/Fill8136/Muon/"
     ]
 
-    df = create_rdataframe(folders)
+    if "8102" in useFiles:
+      print("Using run 8102 files")
+      folders = [entry for entry in folders if "8102" in entry]
+      df = create_rdataframe(folders)
+    elif "8136" in useFiles:
+      print("Using run 8136 files")
+      folders = [entry for entry in folders if "8136" in entry]
+      df = create_rdataframe(folders)
+    elif ".txt" in useFiles:
+      print("Using files in {}".format(useFiles))
+      folders = []
+      inputFiles_run3 = []
+      with open('Run3files.txt') as f:
+        for line in f:
+          line = line.replace('\n',"") # trim newline character
+          inputFiles_run3.append('root://cmsxrootd.fnal.gov/'+line) # prepend with redirector
+      df = ROOT.RDataFrame("Events", tuple(inputFiles_run3))
+
+    else:
+      print("Not a valid inputFiles argument")
+      print("Use 8102, 8136, or a text file of nanoaodfile locations")
+
+
+
+    #print(inputFiles_run3)
+
+    #sys.exit()
     df, branches = obtain_picontuple(df)
     branches.sort()
     branches = [

--- a/producer/picoNtuplizer.py
+++ b/producer/picoNtuplizer.py
@@ -119,9 +119,7 @@ if __name__ == '__main__':
     #inputFiles = (f'/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/SingleMuonV1/Files2/nano_aod_{i}.root' for i in range(0,79))
 
     folders = [
-        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356943/",
         "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356944/",
-        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356945/",
         "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356946/",
         "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356947/",
         "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356948/",

--- a/producer/picoNtuplizer.py
+++ b/producer/picoNtuplizer.py
@@ -99,7 +99,12 @@ def obtain_picontuple(df):
     branches += ["pass_VBFasymtau_uppertauleg", "HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS45_L2NN_eta2p1_CrossL1"]
 
     ## 'VBFasymtau_lowertauleg
+    # FIXME : add back the pass_VBFasymtau_lowertauleg
     branches += ["HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS20_eta2p1_SingleL1"]
+
+    ## VBFditau_Run3_tauleg
+    df = df.Define("pass_VBFditau_Run3_tauleg", PassMuTauFilter)
+    branches += ["pass_VBFditau_Run3_tauleg", "HLT_IsoMu27_MediumDeepTauPFTauHPS20_eta2p1_SingleL1"]
 
     ## VBF+ditau chargedIso Monitoring
     branches += ["HLT_IsoMu20_eta2p1_TightChargedIsoPFTauHPS27_eta2p1_TightID_CrossL1"]
@@ -119,16 +124,16 @@ if __name__ == '__main__':
     #inputFiles = (f'/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/SingleMuonV1/Files2/nano_aod_{i}.root' for i in range(0,79))
 
     folders = [
-        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356944/",
-        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356946/",
-        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356947/",
-        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356948/",
-        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356949/",
-        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356951/",
-        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356954/",
-        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356955/",
-        "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356956/"
-        # "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/savarghe/nanoaod/eraD/Fill8136/Muon/"
+        #"/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356944/",
+        #"/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356946/",
+        #"/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356947/",
+        #"/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356948/",
+        #"/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356949/",
+        #"/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356951/",
+        #"/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356954/",
+        #"/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356955/",
+        #"/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/anayak/2022NanoAOD/Muon_Fill8102/Run356956/"
+         "/eos/cms/store/group/dpg_trigger/comm_trigger/TriggerStudiesGroup/STEAM/savarghe/nanoaod/eraD/Fill8136/Muon/"
     ]
 
     df = create_rdataframe(folders)

--- a/producer/plot_comparison.py
+++ b/producer/plot_comparison.py
@@ -10,8 +10,12 @@ from plotter_from_ntuplizer import obtain_histograms
 parser = argparse.ArgumentParser(description='Skim full tuple.')
 parser.add_argument('--input_A', required=True, type=str, nargs='+', help="first input file")
 parser.add_argument('--input_B', required=True, type=str, nargs='+', help="second input file")
-parser.add_argument('--channel', required=True, type=str, 
-       help="ditau, mutau, etau, VBFasymtau_uppertauleg, VBFasymtau_lowertauleg, ditaujet_tauleg, or ditaujet_jetleg,VBFditau_old")
+parser.add_argument('--channel_A', required=True, type=str, 
+       help="ditau, mutau, etau, VBFasymtau_uppertauleg, VBFasymtau_lowertauleg, ditaujet_tauleg, ditaujet_jetleg, VBFditau_old,\
+       or VBFditau_Run3_tauleg")
+parser.add_argument('--channel_B', required=True, type=str, 
+       help="ditau, mutau, etau, VBFasymtau_uppertauleg, VBFasymtau_lowertauleg, ditaujet_tauleg, ditaujet_jetleg, VBFditau_old,\
+       or VBFditau_Run3_tauleg")
 parser.add_argument('--run', required=True, type=str, help="runs or fill used (look at your input files)")
 parser.add_argument('--plot', required=True, type=str, help="plot name")
 parser.add_argument('--iseta', action='store_true', help="sets flag for eat plotting")
@@ -22,7 +26,8 @@ parser.add_argument('--var', required=True, type=str, help="tau_pt, tau_eta, jet
 #        same for help statement of channel arguments in argparse
 possibleChannels = ["ditau", "mutau", "etau", \
                     "VBFasymtau_uppertauleg", "VBFasymtau_lowertauleg", \
-                    "ditaujet_tauleg", "ditaujet_jetleg","VBFditau_old"]
+                    "ditaujet_tauleg", "ditaujet_jetleg",\
+                    "VBFditau_old", "VBFditau_Run3_tauleg"]
 
 def plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVariable, channel_A, channel_B, add_to_label, plotName):
     print("Plotting {} of {} and {}".format(plottingVariable, channel_A, channel_B))
@@ -89,15 +94,16 @@ def plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVari
 if __name__ == "__main__":
 
     args = parser.parse_args()
-    channel = args.channel
+    channel_A = args.channel_A
+    channel_B = args.channel_B
     #iseta = args.iseta
     plottingVariable = args.var
     iseta = "eta" in "plottingVariable"
     print(iseta)
     print(args.input_A, args.input_B)
     df_A = ROOT.RDataFrame("Events",tuple(args.input_A))
-    h_num_os_A, h_den_os_A = obtain_histograms(df_A, "VBFditau_Run3_tauleg", iseta, plottingVariable)
+    h_num_os_A, h_den_os_A = obtain_histograms(df_A, channel_A, iseta, plottingVariable)
     df_B = ROOT.RDataFrame("Events",tuple(args.input_B))
-    h_num_os_B, h_den_os_B = obtain_histograms(df_B, "VBFditau_Run3_tauleg", iseta, plottingVariable)
+    h_num_os_B, h_den_os_B = obtain_histograms(df_B, channel_B, iseta, plottingVariable)
 
-    plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVariable, "VBFditau_Run3", "VBFditau_Run3", args.run, args.plot)
+    plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVariable, channel_A, channel_B, args.run, args.plot)

--- a/producer/plot_comparison.py
+++ b/producer/plot_comparison.py
@@ -74,6 +74,7 @@ def plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVari
     leg = ROOT.TLegend(0.5, 0.45, 0.85, 0.85)
     leg.AddEntry(gr_A)
     leg.AddEntry(gr_B)
+    leg.Draw()
     # add new leg
     # make user friendly
 

--- a/producer/plot_comparison.py
+++ b/producer/plot_comparison.py
@@ -1,0 +1,99 @@
+#import os, sys
+import ROOT
+ROOT.ROOT.EnableImplicitMT()
+ROOT.gROOT.SetBatch(True)
+
+import argparse
+from plotter_from_ntuplizer import obtain_histograms
+
+
+parser = argparse.ArgumentParser(description='Skim full tuple.')
+parser.add_argument('--input_A', required=True, type=str, nargs='+', help="first input file")
+parser.add_argument('--input_B', required=True, type=str, nargs='+', help="second input file")
+parser.add_argument('--channel', required=True, type=str, 
+       help="ditau, mutau, etau, VBFasymtau_uppertauleg, VBFasymtau_lowertauleg, ditaujet_tauleg, or ditaujet_jetleg,VBFditau_old")
+parser.add_argument('--run', required=True, type=str, help="runs or fill used (look at your input files)")
+parser.add_argument('--plot', required=True, type=str, help="plot name")
+parser.add_argument('--iseta', action='store_true', help="sets flag for eat plotting")
+parser.add_argument('--var', required=True, type=str, help="tau_pt, tau_eta, jet_pt, jet_eta")
+
+
+possibleChannels = ["ditau", "mutau", "etau", \
+                    "VBFasymtau_uppertauleg", "VBFasymtau_lowertauleg", \
+                    "ditaujet_tauleg", "ditaujet_jetleg","VBFditau_old"]
+
+def plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVariable, channel_A, channel_B, add_to_label, plotName):
+    print("Plotting {} of {} and {}".format(plottingVariable, channel_A, channel_B))
+    ROOT.gStyle.SetOptStat(0); ROOT.gStyle.SetTextFont(42)
+    c = ROOT.TCanvas("c", "", 800, 700)
+
+    # use multiplotter for multiple graphs
+    mg = ROOT.TMultiGraph("mg", "")
+
+    # this divides num by den.
+    # the "Clopper-Pearson" interval is not supported for
+    # TGraphAsymmErrors::Divide, so i changed "cp" to "n"
+    # the graphs are not changed
+    # https://root.cern.ch/doc/master/classTGraphAsymmErrors.html#a37a202762b286cf4c7f5d34046be8c0b
+    # use "nv" to get per-bin efficiency printed to terminal
+    gr_A = ROOT.TGraphAsymmErrors(h_num_os_A.GetPtr(),h_den_os_A.GetPtr(), "n")
+    gr_A.SetTitle("")
+    gr_A.SetLineColor(2) # this is red
+    gr_A.SetMarkerStyle(21) # this is a filled box
+    gr_A.SetMarkerSize(1.5)
+
+
+    gr_B = ROOT.TGraphAsymmErrors(h_num_os_B.GetPtr(),h_den_os_B.GetPtr(), "n")
+    gr_B.SetTitle("")
+    gr_B.SetLineColor(9) # this is blue
+    gr_B.SetMarkerStyle(20) # this is a filled circle
+    gr_B.SetMarkerColor(12) # this is a light grey
+    gr_B.SetMarkerSize(1.4)
+
+    mg.Add(gr_A)
+    mg.Add(gr_B)
+    # "P" forces the use of the chosen marker
+    # "A" draws without the axis 
+    # somehow the plot is not drawn without this argument
+    # https://root.cern/doc/master/classTHistPainter.html#HP01a
+    mg.Draw("AP")
+
+    label = ROOT.TLatex(); label.SetNDC(True)
+    if(plottingVariable == "tau_pt" or plottingVariable=="tau_l1pt"):
+        label.DrawLatex(0.8, 0.03, "#tau_{pT}")
+    elif(plottingVariable == "jet_pt"):
+        label.DrawLatex(0.8, 0.03, "jet_{pT}")
+    elif(plottingVariable == "jet_eta"):
+        label.DrawLatex(0.8, 0.03, "#eta_{jet}")
+    else:
+        label.DrawLatex(0.8, 0.03, "#eta_{#tau}")
+    label.SetTextSize(0.040); label.DrawLatex(0.100, 0.920, "#bf{CMS Run3 Data}")
+    label.SetTextSize(0.030); label.DrawLatex(0.630, 0.920, "#sqrt{s} = 13.6 TeV, %s" % add_to_label)
+
+    # add legend
+    leg = ROOT.TLegend(0.5, 0.45, 0.85, 0.85)
+    leg.AddEntry(gr_A)
+    leg.AddEntry(gr_B)
+    # add new leg
+    # make user friendly
+
+    combined_name = channel_A + "_" + channel_B
+    c.SaveAs("%s_%s_%s.pdf" % (plotName, combined_name, plottingVariable))
+    c.SaveAs("%s_%s_%s.png" % (plotName, combined_name, plottingVariable))
+
+
+if __name__ == "__main__":
+
+    args = parser.parse_args()
+    channel = args.channel
+    #iseta = args.iseta
+    plottingVariable = args.var
+    iseta = "eta" in "plottingVariable"
+    print(iseta)
+    print(args.input_A, args.input_B)
+    df_A = ROOT.RDataFrame("Events",tuple(args.input_A))
+    h_num_os_A, h_den_os_A = obtain_histograms(df_A, "VBFditau_old", iseta, plottingVariable)
+    df_B = ROOT.RDataFrame("Events",tuple(args.input_B))
+    h_num_os_B, h_den_os_B = obtain_histograms(df_B, "mutau", iseta, plottingVariable)
+
+    plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVariable, "VBFditau_old", "mutau", args.run, args.plot)

--- a/producer/plot_comparison.py
+++ b/producer/plot_comparison.py
@@ -98,7 +98,6 @@ if __name__ == "__main__":
     channel_B = args.channel_B
     plottingVariable = args.var
     iseta = "eta" in "plottingVariable"
-    print(iseta)
     print(args.input_A, args.input_B)
     df_A = ROOT.RDataFrame("Events",tuple(args.input_A))
     h_num_os_A, h_den_os_A = obtain_histograms(df_A, channel_A, iseta, plottingVariable)

--- a/producer/plot_comparison.py
+++ b/producer/plot_comparison.py
@@ -18,6 +18,8 @@ parser.add_argument('--iseta', action='store_true', help="sets flag for eat plot
 parser.add_argument('--var', required=True, type=str, help="tau_pt, tau_eta, jet_pt, jet_eta")
 
 
+# FIXME: possible channels should be defined in one location and imported where needed
+#        same for help statement of channel arguments in argparse
 possibleChannels = ["ditau", "mutau", "etau", \
                     "VBFasymtau_uppertauleg", "VBFasymtau_lowertauleg", \
                     "ditaujet_tauleg", "ditaujet_jetleg","VBFditau_old"]
@@ -94,8 +96,8 @@ if __name__ == "__main__":
     print(iseta)
     print(args.input_A, args.input_B)
     df_A = ROOT.RDataFrame("Events",tuple(args.input_A))
-    h_num_os_A, h_den_os_A = obtain_histograms(df_A, "VBFditau_old", iseta, plottingVariable)
+    h_num_os_A, h_den_os_A = obtain_histograms(df_A, "VBFditau_Run3_tauleg", iseta, plottingVariable)
     df_B = ROOT.RDataFrame("Events",tuple(args.input_B))
-    h_num_os_B, h_den_os_B = obtain_histograms(df_B, "mutau", iseta, plottingVariable)
+    h_num_os_B, h_den_os_B = obtain_histograms(df_B, "VBFditau_Run3_tauleg", iseta, plottingVariable)
 
-    plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVariable, "VBFditau_old", "mutau", args.run, args.plot)
+    plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVariable, "VBFditau_Run3", "VBFditau_Run3", args.run, args.plot)

--- a/producer/plot_comparison.py
+++ b/producer/plot_comparison.py
@@ -80,8 +80,8 @@ def plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVari
     # add legend
     leg = ROOT.TLegend(0.55, 0.15, 0.90, 0.45)
     leg.SetTextSize(0.045)
-    leg.AddEntry(gr_A, channel_A)
-    leg.AddEntry(gr_B, channel_B)
+    leg.AddEntry(gr_A, "v2p1")
+    leg.AddEntry(gr_B, "v2p5")
     leg.Draw()
     # add new leg
     # make user friendly
@@ -96,7 +96,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
     channel_A = args.channel_A
     channel_B = args.channel_B
-    #iseta = args.iseta
     plottingVariable = args.var
     iseta = "eta" in "plottingVariable"
     print(iseta)

--- a/producer/plot_comparison.py
+++ b/producer/plot_comparison.py
@@ -71,9 +71,10 @@ def plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVari
     label.SetTextSize(0.030); label.DrawLatex(0.630, 0.920, "#sqrt{s} = 13.6 TeV, %s" % add_to_label)
 
     # add legend
-    leg = ROOT.TLegend(0.5, 0.45, 0.85, 0.85)
-    leg.AddEntry(gr_A)
-    leg.AddEntry(gr_B)
+    leg = ROOT.TLegend(0.55, 0.15, 0.90, 0.45)
+    leg.SetTextSize(0.045)
+    leg.AddEntry(gr_A, channel_A)
+    leg.AddEntry(gr_B, channel_B)
     leg.Draw()
     # add new leg
     # make user friendly

--- a/producer/plotter_from_ntuplizer.py
+++ b/producer/plotter_from_ntuplizer.py
@@ -81,10 +81,9 @@ if __name__ == "__main__":
     plottingVariable = args.var
     print(args.input)
     df = ROOT.RDataFrame("Events",tuple(args.input))
-    h_num_os, h_den_os = obtain_histograms(df, channel, iseta, plottingVariable)
-    plot(h_num_os, h_den_os, plottingVariable, channel, args.run, args.plot)
-    #h_num_os_A, h_den_os_A = obtain_histograms(df, "VBFditau_old", iseta, plottingVariable)
-    dfnew = ROOT.RDataFrame("Events",tuple(args.input))
-    #h_num_os_B, h_den_os_B = obtain_histograms(dfnew, "mutau", iseta, plottingVariable)
+    #h_num_os, h_den_os = obtain_histograms(df, channel, iseta, plottingVariable)
+    #plot(h_num_os, h_den_os, plottingVariable, channel, args.run, args.plot)
+    h_num_os_A, h_den_os_A = obtain_histograms(df, "VBFditau_old", iseta, plottingVariable)
+    h_num_os_B, h_den_os_B = obtain_histograms(df, "mutau", iseta, plottingVariable)
 
-    #plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVariable, "VBFditau_old", "mutau", args.run, args.plot)
+    plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVariable, "VBFditau_old", "mutau", args.run, args.plot)

--- a/producer/plotter_from_ntuplizer.py
+++ b/producer/plotter_from_ntuplizer.py
@@ -30,7 +30,7 @@ def obtain_histograms(df, channel, iseta, plottingVariable):
     if channel != "ditaujet_jetleg":
         assert "jet" not in plottingVariable
         df = df.Filter("passZmass == 1").Define("tau_pt", "Tau_pt[Tau_Index]").Define("tau_eta", "Tau_eta[Tau_Index]")
-        if args.iseta:
+        if iseta:
           df = df.Filter('tau_pt > 35')  
         h_den_os = df.Histo1D(CreateHistModel("denominator", iseta), plottingVariable)
         # numerator histogram

--- a/producer/plotter_from_ntuplizer.py
+++ b/producer/plotter_from_ntuplizer.py
@@ -81,9 +81,9 @@ if __name__ == "__main__":
     plottingVariable = args.var
     print(args.input)
     df = ROOT.RDataFrame("Events",tuple(args.input))
-    #h_num_os, h_den_os = obtain_histograms(df, channel, iseta, plottingVariable)
-    #plot(h_num_os, h_den_os, plottingVariable, channel, args.run, args.plot)
-    h_num_os_A, h_den_os_A = obtain_histograms(df, "VBFditau_old", iseta, plottingVariable)
-    h_num_os_B, h_den_os_B = obtain_histograms(df, "mutau", iseta, plottingVariable)
+    h_num_os, h_den_os = obtain_histograms(df, channel, iseta, plottingVariable)
+    plot(h_num_os, h_den_os, plottingVariable, channel, args.run, args.plot)
+    #h_num_os_A, h_den_os_A = obtain_histograms(df, "VBFditau_old", iseta, plottingVariable)
+    #h_num_os_B, h_den_os_B = obtain_histograms(df, "mutau", iseta, plottingVariable)
 
-    plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVariable, "VBFditau_old", "mutau", args.run, args.plot)
+    #plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVariable, "VBFditau_old", "mutau", args.run, args.plot)

--- a/producer/plotter_from_ntuplizer.py
+++ b/producer/plotter_from_ntuplizer.py
@@ -11,7 +11,10 @@ from RooPlottingTool import *
 parser = argparse.ArgumentParser(description='Skim full tuple.')
 parser.add_argument('--input', required=True, type=str, nargs='+', help="input files")
 parser.add_argument('--channel', required=True, type=str, 
-       help="ditau, mutau, etau, VBFasymtau_uppertauleg, VBFasymtau_lowertauleg, ditaujet_tauleg, or ditaujet_jetleg,VBFditau_old")
+       help="ditau, mutau, etau, \
+             VBFasymtau_uppertauleg, VBFasymtau_lowertauleg, \
+             ditaujet_tauleg, ditaujet_jetleg, \
+             VBFditau_old, VBFditau_Run3_tauleg")
 parser.add_argument('--run', required=True, type=str, help="runs or fill used (look at your input files)")
 parser.add_argument('--plot', required=True, type=str, help="plot name")
 parser.add_argument('--iseta', action='store_true', help="sets flag for eat plotting")
@@ -20,7 +23,8 @@ parser.add_argument('--var', required=True, type=str, help="tau_pt, tau_eta, jet
 
 possibleChannels = ["ditau", "mutau", "etau", \
                     "VBFasymtau_uppertauleg", "VBFasymtau_lowertauleg", \
-                    "ditaujet_tauleg", "ditaujet_jetleg","VBFditau_old"]
+                    "ditaujet_tauleg", "ditaujet_jetleg", \
+                    "VBFditau_old", "VBFditau_Run3_tauleg"]
 
 
 def obtain_histograms(df, channel, iseta, plottingVariable):
@@ -36,7 +40,8 @@ def obtain_histograms(df, channel, iseta, plottingVariable):
         # numerator histogram
         if channel == 'ditau':
             h_num_os = df.Filter("pass_ditau > 0.5 && \
-                HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS35_L2NN_eta2p1_CrossL1 == 1").Histo1D(CreateHistModel("numerator", iseta), plottingVariable, 'weight')
+                HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS35_L2NN_eta2p1_CrossL1 == 1").Histo1D( \
+                CreateHistModel("numerator", iseta), plottingVariable, 'weight')
 
         elif channel == 'mutau':
             h_num_os = df.Filter("pass_mutau > 0.5 && \
@@ -48,15 +53,23 @@ def obtain_histograms(df, channel, iseta, plottingVariable):
                          HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS45_L2NN_eta2p1_CrossL1 == 1").Histo1D( \
                          CreateHistModel("numerator", iseta), plottingVariable, 'weight')
 
+        #FIXME: this should be lowertauleg, right?
         elif channel == 'VBFasymtau_lowertauleg':
             h_num_os = df.Filter("pass_VBFasymtau_uppertauleg > 0.5 && \
                          HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS20_eta2p1_SingleL1 == 1").Histo1D( \
                          CreateHistModel("numerator", iseta), plottingVariable, 'weight')
 
+        #FIXME: this is Run2 mutau monitoring path, update everywhere
         elif channel == 'VBFditau_old':
             h_num_os = df.Filter("pass_VBFasymtau_uppertauleg > 0.5 && \
                          HLT_IsoMu20_eta2p1_TightChargedIsoPFTauHPS27_eta2p1_TightID_CrossL1 == 1").Histo1D( \
                          CreateHistModel("numerator", iseta), plottingVariable, 'weight')
+
+        elif channel == 'VBFditau_Run3_tauleg':
+            h_num_os = df.Filter("pass_VBFditau_Run3_tauleg > 0.5 && \
+                         HLT_IsoMu27_MediumDeepTauPFTauHPS20_eta2p1_SingleL1 == 1").Histo1D( \
+                         CreateHistModel("numerator", iseta), plottingVariable, 'weight')
+                         #HLT_IsoMu20_eta2p1_TightChargedIsoPFTauHPS27_eta2p1_TightID_CrossL1 == 1").Histo1D( \
 
         elif channel == 'ditaujet_tauleg':
             h_num_os = df.Filter("pass_ditau > 0.5 && \

--- a/producer/plotter_from_ntuplizer.py
+++ b/producer/plotter_from_ntuplizer.py
@@ -4,7 +4,7 @@ ROOT.ROOT.EnableImplicitMT()
 ROOT.gROOT.SetBatch(True)
 
 import argparse
-from picoNtupler_TandP import plot
+from picoNtupler_TandP import plot, plot_comparison
 from RooPlottingTool import *
 
 
@@ -81,6 +81,10 @@ if __name__ == "__main__":
     plottingVariable = args.var
     print(args.input)
     df = ROOT.RDataFrame("Events",tuple(args.input))
-    h_num_os, h_den_os = obtain_histograms(df, channel, iseta, plottingVariable)
+    #h_num_os, h_den_os = obtain_histograms(df, channel, iseta, plottingVariable)
+    #plot(h_num_os, h_den_os, plottingVariable, channel, args.run, args.plot)
+    h_num_os_A, h_den_os_A = obtain_histograms(df, "VBFditau_old", iseta, plottingVariable)
+    dfnew = ROOT.RDataFrame("Events",tuple(args.input))
+    h_num_os_B, h_den_os_B = obtain_histograms(dfnew, "mutau", iseta, plottingVariable)
 
-    plot(h_num_os, h_den_os, plottingVariable, channel, args.run, args.plot)
+    plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVariable, "VBFditau_old", "mutau", args.run, args.plot)

--- a/producer/plotter_from_ntuplizer.py
+++ b/producer/plotter_from_ntuplizer.py
@@ -81,10 +81,10 @@ if __name__ == "__main__":
     plottingVariable = args.var
     print(args.input)
     df = ROOT.RDataFrame("Events",tuple(args.input))
-    #h_num_os, h_den_os = obtain_histograms(df, channel, iseta, plottingVariable)
-    #plot(h_num_os, h_den_os, plottingVariable, channel, args.run, args.plot)
-    h_num_os_A, h_den_os_A = obtain_histograms(df, "VBFditau_old", iseta, plottingVariable)
+    h_num_os, h_den_os = obtain_histograms(df, channel, iseta, plottingVariable)
+    plot(h_num_os, h_den_os, plottingVariable, channel, args.run, args.plot)
+    #h_num_os_A, h_den_os_A = obtain_histograms(df, "VBFditau_old", iseta, plottingVariable)
     dfnew = ROOT.RDataFrame("Events",tuple(args.input))
-    h_num_os_B, h_den_os_B = obtain_histograms(dfnew, "mutau", iseta, plottingVariable)
+    #h_num_os_B, h_den_os_B = obtain_histograms(dfnew, "mutau", iseta, plottingVariable)
 
-    plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVariable, "VBFditau_old", "mutau", args.run, args.plot)
+    #plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVariable, "VBFditau_old", "mutau", args.run, args.plot)

--- a/producer/plotter_from_ntuplizer.py
+++ b/producer/plotter_from_ntuplizer.py
@@ -4,7 +4,7 @@ ROOT.ROOT.EnableImplicitMT()
 ROOT.gROOT.SetBatch(True)
 
 import argparse
-from picoNtupler_TandP import plot, plot_comparison
+from picoNtupler_TandP import plot
 from RooPlottingTool import *
 
 
@@ -83,7 +83,3 @@ if __name__ == "__main__":
     df = ROOT.RDataFrame("Events",tuple(args.input))
     h_num_os, h_den_os = obtain_histograms(df, channel, iseta, plottingVariable)
     plot(h_num_os, h_den_os, plottingVariable, channel, args.run, args.plot)
-    #h_num_os_A, h_den_os_A = obtain_histograms(df, "VBFditau_old", iseta, plottingVariable)
-    #h_num_os_B, h_den_os_B = obtain_histograms(df, "mutau", iseta, plottingVariable)
-
-    #plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVariable, "VBFditau_old", "mutau", args.run, args.plot)


### PR DESCRIPTION
Separated plot_comparison function to its own file with its own argparse handling
Added VBFditau_Run3_tauleg to picoNtuplizer.py and plotter_from_picoNtuplizer.py
Removed runs 356943 and 356945 as they were declared bad for physics by STEAM. 
Added fill handling to picoNtupler_TandP.py (i.e. files are automatically picked depending on run argument)
Added note to obtain_histograms in picoNtupler_TandP.py about usage of correct "ravVsJet" score variable
Changed plotting options to prevent warning messages appearing in terminal (graphs are not changed)