### PR TITLE
Formatting Updates and Changes to VBFasymtau_uppertauleg

### DIFF
--- a/interface/trigger_bit_to_hlt_module.txt
+++ b/interface/trigger_bit_to_hlt_module.txt
@@ -1,0 +1,24 @@
+# Updated November 02, 2022 by Braden Allmond
+# referencing: https://github.com/cms-sw/cmssw/blob/master/PhysicsTools/NanoAOD/python/V10/triggerObjects_cff.py
+
+# Format
+# function (object referred to)
+# trigger bits,  string used 
+
+PassTagFilter (Muon)
+8, 8*max(max(filter('hltL3crIsoL1*SingleMu*Filtered0p07'),filter('hltL3crIsoL1sMu*Filtered0p07')),max(filter('hltL3crIsoL1*SingleMu*Filtered0p08'),filter('hltL3crIsoL1sMu*Filtered0p08')))
+
+
+PassDiTauFilter (Tau)
+512, 512*filter('hlt*OverlapFilterIsoMu*PFTau*')
+1024, 1024*filter('hlt*SelectedPFTau*L1HLTMatched')
+
+PassDiTauJetFilter (Jet)
+2097152, 2097152*filter('hltHpsOverlapFilterDeepTauPFTau*PFJet*')
+
+PassMuTauFilter (Tau)
+512, 512*filter('hlt*OverlapFilterIsoMu*PFTau*')
+
+PassElTauFilter (Tau)
+512, 512*filter('hlt*OverlapFilterIsoMu*PFTau*')
+

--- a/producer/channel_to_HLT_map.py
+++ b/producer/channel_to_HLT_map.py
@@ -8,7 +8,7 @@ channel_to_HLT_map = {
   "ditaujet_tauleg"        : "HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS30_L2NN_eta2p1_CrossL1",
   "ditaujet_jetleg"        : "HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS30_L2NN_eta2p1_PFJet60_CrossL1",
 
-  "VBFditau_old"           : "HLT_IsoMu20_eta2p1_TightChargedIsoPFTauHPS27_eta2p1_TightID_CrossL1",
+  "mutau_Run2"           : "HLT_IsoMu20_eta2p1_TightChargedIsoPFTauHPS27_eta2p1_TightID_CrossL1",
   "VBFditau_Run3_tauleg"   : "HLT_IsoMu27_MediumDeepTauPFTauHPS20_eta2p1_SingleL1",
 }
 

--- a/producer/channel_to_HLT_map.py
+++ b/producer/channel_to_HLT_map.py
@@ -1,0 +1,14 @@
+channel_to_HLT_map = {
+  "muon_tag" : "HLT_IsoMu24_eta2p1",
+  "ditau"  : "HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS35_L2NN_eta2p1_CrossL1",
+  "mutau"  : "HLT_IsoMu20_eta2p1_LooseDeepTauPFTauHPS27_eta2p1_CrossL1",
+  #"etau"   : "Not_Implemented"  
+  "VBFasymtau_uppertauleg" : "HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS45_L2NN_eta2p1_CrossL1",
+  "VBFasymtau_lowertauleg" : "HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS20_eta2p1_SingleL1",
+  "ditaujet_tauleg"        : "HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS30_L2NN_eta2p1_CrossL1",
+  "ditaujet_jetleg"        : "HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS30_L2NN_eta2p1_PFJet60_CrossL1",
+
+  "VBFditau_old"           : "HLT_IsoMu20_eta2p1_TightChargedIsoPFTauHPS27_eta2p1_TightID_CrossL1",
+  "VBFditau_Run3_tauleg"   : "HLT_IsoMu27_MediumDeepTauPFTauHPS20_eta2p1_SingleL1",
+}
+

--- a/producer/multicomparer_from_ntuplizer.py
+++ b/producer/multicomparer_from_ntuplizer.py
@@ -1,0 +1,54 @@
+from plotter_from_ntuplizer import *
+from plot_comparison import plot_comparison
+
+# folders = ["/eos/user/b/ballmond/muonNanoAOD2022D/", "/eos/user/j/jleonhol/muonNanoAOD2022D_notrigobj/"]
+folders = ["/eos/user/j/jleonhol/muonNanoAOD2022D_notrigobj/", "/eos/user/j/jleonhol/muonNanoAOD2022E/"]
+# legends = ["w/ offl-trigger matching", "w/o offl-trigger matching"]
+legends = ["Run2022D (no match)", "Run2022E (no match)"]
+
+def create_rdataframe(folders=None, inputFiles=None):
+    if not inputFiles:
+        inputFiles = []
+        for folder in folders:
+            files = os.listdir(folder)
+            inputFiles += [os.path.join(folder, f) for f in files if f.endswith(".root")]
+    print(inputFiles)
+    return ROOT.RDataFrame("Events", tuple(inputFiles))
+
+dfs = [create_rdataframe(folders=[folder]) for folder in folders]
+
+# plotname = "comparison_muon2022d"
+# label = "Muon - 2022D"
+
+plotname = "comparison_muon2022de"
+label = "Muon - 2022D/E"
+
+
+histos = []
+channel_variables = [
+    ("ditau", ["tau_pt", "tau_eta"]),
+    ("ditaujet_tauleg", ["tau_pt", "tau_eta"]),
+    ("ditaujet_jetleg", ["jet_pt", "jet_eta"]),
+]
+
+for df in dfs:
+    histos.append({})
+    for channel, plottingVariables in channel_variables:
+        for plottingVariable in plottingVariables:
+            iseta = "eta" in plottingVariable
+            histos[-1]["num_%s_%s" % (channel, plottingVariable)], histos[-1]["den_%s_%s" % (channel, plottingVariable)]\
+                = obtain_histograms(df, channel, iseta, plottingVariable)
+
+for channel, plottingVariables in channel_variables:
+    for plottingVariable in plottingVariables:
+        plot_comparison(
+            histos[0]["num_%s_%s" % (channel, plottingVariable)],
+            histos[0]["den_%s_%s" % (channel, plottingVariable)],
+            histos[1]["num_%s_%s" % (channel, plottingVariable)],
+            histos[1]["den_%s_%s" % (channel, plottingVariable)],
+            plottingVariable,
+            channel,
+            channel,
+            label,
+            plotname,
+            legends)

--- a/producer/multicomparer_from_ntuplizer.py
+++ b/producer/multicomparer_from_ntuplizer.py
@@ -27,6 +27,9 @@ label = "Muon - 2022D/E"
 histos = []
 channel_variables = [
     ("ditau", ["tau_pt", "tau_eta"]),
+    ("mutau", ["tau_pt", "tau_eta"]),
+    ("VBFasymtau_uppertauleg", ["tau_pt", "tau_eta"]),
+    ("VBFasymtau_lowertauleg", ["tau_pt", "tau_eta"]),
     ("ditaujet_tauleg", ["tau_pt", "tau_eta"]),
     ("ditaujet_jetleg", ["jet_pt", "jet_eta"]),
 ]

--- a/producer/picoNtuplizer.py
+++ b/producer/picoNtuplizer.py
@@ -106,14 +106,20 @@ def obtain_picontuple(df):
     branches += ["pass_VBFasymtau_uppertauleg", "HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS45_L2NN_eta2p1_CrossL1"]
 
     ## VBFasymtau_lowertauleg
-    branches += ["HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS20_eta2p1_SingleL1"]
+    df = df.Define("pass_VBFasymtau_lowertauleg", PassMuTauFilter)
+    branches += ["pass_VBFasymtau_lowertauleg", "HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS20_eta2p1_SingleL1"]
 
     ## VBFditau_Run3_tauleg
     df = df.Define("pass_VBFditau_Run3_tauleg", PassMuTauFilter)
     branches += ["pass_VBFditau_Run3_tauleg", "HLT_IsoMu27_MediumDeepTauPFTauHPS20_eta2p1_SingleL1"]
+    # could be monitored equally well with HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS20_eta2p1_SingleL1_v2
+    # would be good to check and remove the IsoMu27 path
+    #branches += ["pass_VBFditau_Run3_tauleg", "HLT_IsoMu24_MediumDeepTauPFTauHPS20_eta2p1_SingleL1"]
 
     ## mutau_Run2
-    branches += ["HLT_IsoMu20_eta2p1_TightChargedIsoPFTauHPS27_eta2p1_TightID_CrossL1"]
+    df = df.Define("pass_mutau_Run2", PassMuTauFilter)
+    branches += ["pass_mutau_Run2", "HLT_IsoMu20_eta2p1_TightChargedIsoPFTauHPS27_eta2p1_TightID_CrossL1"]
+
     ## ditaujet_jetleg
     df = df.Define("pass_ditau_jet",
         "PassDiTauJetFilter(nTrigObj, TrigObj_id, TrigObj_filterBits, TrigObj_pt, TrigObj_eta, TrigObj_phi, \

--- a/producer/picoNtuplizer.py
+++ b/producer/picoNtuplizer.py
@@ -112,7 +112,7 @@ def obtain_picontuple(df):
     df = df.Define("pass_VBFditau_Run3_tauleg", PassMuTauFilter)
     branches += ["pass_VBFditau_Run3_tauleg", "HLT_IsoMu27_MediumDeepTauPFTauHPS20_eta2p1_SingleL1"]
 
-    ## VBF+ditau chargedIso Monitoring
+    ## mutau_Run2
     branches += ["HLT_IsoMu20_eta2p1_TightChargedIsoPFTauHPS27_eta2p1_TightID_CrossL1"]
     ## ditaujet_jetleg
     df = df.Define("pass_ditau_jet",

--- a/producer/plot_comparison.py
+++ b/producer/plot_comparison.py
@@ -29,7 +29,7 @@ possibleChannels = ["ditau", "mutau", "etau", \
                     "ditaujet_tauleg", "ditaujet_jetleg",\
                     "VBFditau_old", "VBFditau_Run3_tauleg"]
 
-def plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVariable, channel_A, channel_B, add_to_label, plotName):
+def plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVariable, channel_A, channel_B, add_to_label, plotName, legends=["v2p1", "v2p5"]):
     print("Plotting {} of {} and {}".format(plottingVariable, channel_A, channel_B))
     ROOT.gStyle.SetOptStat(0); ROOT.gStyle.SetTextFont(42)
     c = ROOT.TCanvas("c", "", 800, 700)
@@ -80,8 +80,8 @@ def plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVari
     # add legend
     leg = ROOT.TLegend(0.55, 0.15, 0.90, 0.45)
     leg.SetTextSize(0.045)
-    leg.AddEntry(gr_A, "v2p1")
-    leg.AddEntry(gr_B, "v2p5")
+    leg.AddEntry(gr_A, legends[0])
+    leg.AddEntry(gr_B, legends[1])
     leg.Draw()
     # add new leg
     # make user friendly

--- a/producer/plot_comparison.py
+++ b/producer/plot_comparison.py
@@ -5,6 +5,7 @@ ROOT.gROOT.SetBatch(True)
 
 import argparse
 from plotter_from_ntuplizer import obtain_histograms
+from channel_to_HLT_map import channel_to_HLT_map
 
 
 parser = argparse.ArgumentParser(description='Skim full tuple.')
@@ -61,7 +62,7 @@ def plot_comparison(h_num_os_A, h_den_os_A, \
     gr_B.SetLineColor(9) # this is blue
     gr_B.SetMarkerStyle(20) # this is a filled circle
     gr_B.SetMarkerColor(12) # this is a light grey
-    gr_B.SetMarkerSize(1.4)
+    gr_B.SetMarkerSize(1.3)
 
     mg.Add(gr_A)
     mg.Add(gr_B)
@@ -82,6 +83,7 @@ def plot_comparison(h_num_os_A, h_den_os_A, \
         label.DrawLatex(0.8, 0.03, "#eta_{#tau}")
     label.SetTextSize(0.040); label.DrawLatex(0.100, 0.920, "#bf{CMS Run3 Data}")
     label.SetTextSize(0.030); label.DrawLatex(0.630, 0.920, "#sqrt{s} = 13.6 TeV, %s" % add_to_label)
+    label.SetTextSize(0.025); label.DrawLatex(0.110, 0.870, channel_to_HLT_map[channel_A])
 
     # add legend
     leg = ROOT.TLegend(0.60, 0.15, 0.90, 0.25)

--- a/producer/plot_comparison.py
+++ b/producer/plot_comparison.py
@@ -29,7 +29,13 @@ possibleChannels = ["ditau", "mutau", "etau", \
                     "ditaujet_tauleg", "ditaujet_jetleg",\
                     "VBFditau_old", "VBFditau_Run3_tauleg"]
 
-def plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVariable, channel_A, channel_B, add_to_label, plotName, legends=["v2p1", "v2p5"]):
+def plot_comparison(h_num_os_A, h_den_os_A, \
+                    h_num_os_B, h_den_os_B, \
+                    plottingVariable, \
+                    channel_A, channel_B, \
+                    add_to_label, plotName, \
+                    legends=["v2p1", "v2p5"]):
+
     print("Plotting {} of {} and {}".format(plottingVariable, channel_A, channel_B))
     ROOT.gStyle.SetOptStat(0); ROOT.gStyle.SetTextFont(42)
     c = ROOT.TCanvas("c", "", 800, 700)
@@ -67,9 +73,9 @@ def plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVari
 
     label = ROOT.TLatex(); label.SetNDC(True)
     if(plottingVariable == "tau_pt" or plottingVariable=="tau_l1pt"):
-        label.DrawLatex(0.8, 0.03, "#tau_{pT}")
+        label.DrawLatex(0.8, 0.03, "p_{T}^{#tau}") ##tau_{pT}")
     elif(plottingVariable == "jet_pt"):
-        label.DrawLatex(0.8, 0.03, "jet_{pT}")
+        label.DrawLatex(0.8, 0.03, "p_{T}^{jet}") #jet_{pT}")
     elif(plottingVariable == "jet_eta"):
         label.DrawLatex(0.8, 0.03, "#eta_{jet}")
     else:
@@ -78,13 +84,11 @@ def plot_comparison(h_num_os_A, h_den_os_A, h_num_os_B, h_den_os_B, plottingVari
     label.SetTextSize(0.030); label.DrawLatex(0.630, 0.920, "#sqrt{s} = 13.6 TeV, %s" % add_to_label)
 
     # add legend
-    leg = ROOT.TLegend(0.55, 0.15, 0.90, 0.45)
-    leg.SetTextSize(0.045)
+    leg = ROOT.TLegend(0.60, 0.15, 0.90, 0.25)
+    leg.SetTextSize(0.025)
     leg.AddEntry(gr_A, legends[0])
     leg.AddEntry(gr_B, legends[1])
     leg.Draw()
-    # add new leg
-    # make user friendly
 
     combined_name = channel_A + "_" + channel_B
     c.SaveAs("%s_%s_%s.pdf" % (plotName, combined_name, plottingVariable))

--- a/producer/plotter_from_ntuplizer.py
+++ b/producer/plotter_from_ntuplizer.py
@@ -14,7 +14,7 @@ parser.add_argument('--channel', required=True, type=str,
        help="ditau, mutau, etau, \
              VBFasymtau_uppertauleg, VBFasymtau_lowertauleg, \
              ditaujet_tauleg, ditaujet_jetleg, \
-             VBFditau_old, VBFditau_Run3_tauleg")
+             mutau_Run2, VBFditau_Run3_tauleg")
 parser.add_argument('--data_label', required=True, type=str, help="graph label describing dataset used")
 parser.add_argument('--plot', required=True, type=str, help="plot name")
 parser.add_argument('--iseta', action='store_true', help="sets flag for eat plotting")
@@ -24,7 +24,7 @@ parser.add_argument('--var', required=True, type=str, help="tau_pt, tau_eta, jet
 possibleChannels = ["ditau", "mutau", "etau", \
                     "VBFasymtau_uppertauleg", "VBFasymtau_lowertauleg", \
                     "ditaujet_tauleg", "ditaujet_jetleg", \
-                    "VBFditau_old", "VBFditau_Run3_tauleg"]
+                    "mutau_Run2", "VBFditau_Run3_tauleg"]
 
 
 def obtain_histograms(df, channel, iseta, plottingVariable):
@@ -50,8 +50,9 @@ def obtain_histograms(df, channel, iseta, plottingVariable):
 
         elif channel == 'VBFasymtau_uppertauleg':
             h_num_os = df.Filter("pass_VBFasymtau_uppertauleg >= 0 && \
-                         HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS45_L2NN_eta2p1_CrossL1 == 1").Histo1D( \
-                         CreateHistModel("numerator", iseta), plottingVariable, 'weight')
+                         HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS45_L2NN_eta2p1_CrossL1 == 1"\
+                         ).Filter("TrigObj_l1pt.at(pass_ditau) >= 45 && TrigObj_l1iso.at(pass_ditau) > 0"\
+                         ).Histo1D(CreateHistModel("numerator", iseta), plottingVariable, 'weight')
 
         #FIXME: this should be lowertauleg, right?
         elif channel == 'VBFasymtau_lowertauleg':
@@ -59,12 +60,14 @@ def obtain_histograms(df, channel, iseta, plottingVariable):
                          HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS20_eta2p1_SingleL1 == 1").Histo1D( \
                          CreateHistModel("numerator", iseta), plottingVariable, 'weight')
 
-        #FIXME: this is Run2 mutau monitoring path, update everywhere
-        elif channel == 'VBFditau_old':
+        #FIXME: this is Run2 mutau monitoring path
+        elif channel == 'mutau_Run2':
             h_num_os = df.Filter("pass_VBFasymtau_uppertauleg >= 0 && \
                          HLT_IsoMu20_eta2p1_TightChargedIsoPFTauHPS27_eta2p1_TightID_CrossL1 == 1").Histo1D( \
                          CreateHistModel("numerator", iseta), plottingVariable, 'weight')
 
+        # could be monitored equally well with HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS20_eta2p1_SingleL1_v2
+        # this was the intention when that path was made, but somehow the IsoMu27 version wasn't removed
         elif channel == 'VBFditau_Run3_tauleg':
             h_num_os = df.Filter("pass_VBFditau_Run3_tauleg >= 0 && \
                          HLT_IsoMu27_MediumDeepTauPFTauHPS20_eta2p1_SingleL1 == 1").Histo1D( \

--- a/producer/plotter_from_ntuplizer.py
+++ b/producer/plotter_from_ntuplizer.py
@@ -54,15 +54,13 @@ def obtain_histograms(df, channel, iseta, plottingVariable):
                          ).Filter("TrigObj_l1pt.at(pass_ditau) >= 45 && TrigObj_l1iso.at(pass_ditau) > 0"\
                          ).Histo1D(CreateHistModel("numerator", iseta), plottingVariable, 'weight')
 
-        #FIXME: this should be lowertauleg, right?
         elif channel == 'VBFasymtau_lowertauleg':
-            h_num_os = df.Filter("pass_VBFasymtau_uppertauleg >= 0 && \
+            h_num_os = df.Filter("pass_VBFasymtau_lowertauleg >= 0 && \
                          HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS20_eta2p1_SingleL1 == 1").Histo1D( \
                          CreateHistModel("numerator", iseta), plottingVariable, 'weight')
 
-        #FIXME: this is Run2 mutau monitoring path
         elif channel == 'mutau_Run2':
-            h_num_os = df.Filter("pass_VBFasymtau_uppertauleg >= 0 && \
+            h_num_os = df.Filter("pass_mutau_Run2 >= 0 && \
                          HLT_IsoMu20_eta2p1_TightChargedIsoPFTauHPS27_eta2p1_TightID_CrossL1 == 1").Histo1D( \
                          CreateHistModel("numerator", iseta), plottingVariable, 'weight')
 

--- a/producer/plotter_from_ntuplizer.py
+++ b/producer/plotter_from_ntuplizer.py
@@ -51,16 +51,18 @@ def obtain_histograms(df, channel, iseta, plottingVariable):
         elif channel == 'VBFasymtau_uppertauleg':
             h_num_os = df.Filter("pass_VBFasymtau_uppertauleg >= 0 && \
                          HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS45_L2NN_eta2p1_CrossL1 == 1"\
-                         ).Filter("TrigObj_l1pt.at(pass_ditau) >= 45 && TrigObj_l1iso.at(pass_ditau) > 0"\
+                         ).Filter("TrigObj_l1pt.at(pass_mutau) >= 45 && TrigObj_l1iso.at(pass_mutau) > 0"
                          ).Histo1D(CreateHistModel("numerator", iseta), plottingVariable, 'weight')
 
         elif channel == 'VBFasymtau_lowertauleg':
-            h_num_os = df.Filter("pass_VBFasymtau_lowertauleg >= 0 && \
+            #h_num_os = df.Filter("pass_VBFasymtau_lowertauleg >= 0 && \
+            h_num_os = df.Filter("pass_VBFasymtau_uppertauleg >= 0 && \
                          HLT_IsoMu24_eta2p1_MediumDeepTauPFTauHPS20_eta2p1_SingleL1 == 1").Histo1D( \
                          CreateHistModel("numerator", iseta), plottingVariable, 'weight')
 
         elif channel == 'mutau_Run2':
-            h_num_os = df.Filter("pass_mutau_Run2 >= 0 && \
+            #h_num_os = df.Filter("pass_mutau_Run2 >= 0 && \
+            h_num_os = df.Filter("pass_VBFasymtau_uppertauleg >= 0 && \
                          HLT_IsoMu20_eta2p1_TightChargedIsoPFTauHPS27_eta2p1_TightID_CrossL1 == 1").Histo1D( \
                          CreateHistModel("numerator", iseta), plottingVariable, 'weight')
 


### PR DESCRIPTION
Hello, in this PR I added some "quality of life" improvements like 
-a dictionary with channel names and the associated HLT
-a text file with the trigger bit info
-a correction of the "VBFditau_old" channel name to "mutau_Run2"

An important change was made to VBFasymtau_uppertauleg. It now includes an L1pt requirement and L1IsoTau requirement. This is necessary since the path was designed to monitor the upper tau leg of the VBF+DiTau HLT, which is seeded by an L1 Iso Tau and two jets. I've made some plots on 2022D data to compare the turn-on before and after including this change. Things look how I expect, and they can be viewed here (https://docs.google.com/presentation/d/1O7f3s6blI_RjIF0Y1CqViQZR_PIXCBqz1ubqZwntS8o/edit?usp=sharing). The turn-on is slower than before because L1IsoTau has a slower turn-on. I would like to look at the impact of plotting/rebinning on these plots as well. 

Also included in this PR are changes I merged from Jaime, which introduce a multiplotter for path/dataset comparisons. 